### PR TITLE
Implement gaussian filter before downsamping

### DIFF
--- a/gpu_stereo_image_proc_visionworks/CMakeLists.txt
+++ b/gpu_stereo_image_proc_visionworks/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${VX_NODELET_NAME}
             src/vx_stereo_matcher_base.cpp
             src/vx_stereo_matcher.cpp
             src/vx_bidirectional_stereo_matcher.cpp
+            src/vx_image_scaler.cpp
             src/vx_conversions.cpp
             src/nodelet/vx_disparity.cpp)
 target_link_libraries(${VX_NODELET_NAME} ${catkin_LIBRARIES}

--- a/gpu_stereo_image_proc_visionworks/cfg/VXSGBM.cfg
+++ b/gpu_stereo_image_proc_visionworks/cfg/VXSGBM.cfg
@@ -2,14 +2,19 @@
 
 # Declare parameters that control stereo processing
 
-PACKAGE='gpu_stereo_image_proc'
 
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
 # disparity block matching pre-filtering parameters
-gen.add("downsample", int_t, 0, "Images will be downsampled before processing. Must be a power of 2.", 1, 1, 64)
+downsample_enum = gen.enum([gen.const("Downsample_1",    int_t, 0, "Process image at full scale"),
+                           gen.const("Downsample_2",     int_t, 1, "Shrink images by 2 in both dimensions before processing"),
+                           gen.const("Downsample_4",     int_t, 2, "Shrink images by 4 in both dimensions before processing"),
+                           gen.const("Downsample_8",     int_t, 3, "Shrink images by 8 in both dimensions before processing")],
+                           "Image downsampling")
+gen.add("downsample", int_t, 0, "Downsample ratio", 2, 0, 3,
+        edit_method = downsample_enum)
 
 # disparity block matching correlation parameters
 gen.add("correlation_window_size", int_t, 0, "SAD correlation window width, pixels", 5, 5, 31)
@@ -54,4 +59,4 @@ gen.add("disparity_filter", int_t, 0, "Disparity filtering", 0, 0, 3, edit_metho
 
 gen.add("confidence_threshold", int_t, 0, "If confidence is available, retain points above this confidence (set to 0 to disable", 0, 0, 255);
 
-exit(gen.generate(PACKAGE, "gpu_stereo_image_proc_visionworks", "VXSGBM"))
+exit(gen.generate("gpu_stereo_image_proc_visionworks", "gpu_stereo_image_proc_visionworks", "VXSGBM"))

--- a/gpu_stereo_image_proc_visionworks/cfg/VXSGBM.cfg
+++ b/gpu_stereo_image_proc_visionworks/cfg/VXSGBM.cfg
@@ -9,10 +9,10 @@ gen = ParameterGenerator()
 
 # disparity block matching pre-filtering parameters
 downsample_enum = gen.enum([gen.const("Downsample_1",    int_t, 0, "Process image at full scale"),
-                           gen.const("Downsample_2",     int_t, 1, "Shrink images by 2 in both dimensions before processing"),
-                           gen.const("Downsample_4",     int_t, 2, "Shrink images by 4 in both dimensions before processing"),
-                           gen.const("Downsample_8",     int_t, 3, "Shrink images by 8 in both dimensions before processing")],
-                           "Image downsampling")
+                           gen.const("Downsample_2",     int_t, 1, "Shrink images by factor of 2 in both axes before processing"),
+                           gen.const("Downsample_4",     int_t, 2, "Shrink images by factor of 4 in both axes before processing"),
+                           gen.const("Downsample_8",     int_t, 3, "Shrink images by factor of 8 in both axes before processing")],
+                           "Image downsampling factor")
 gen.add("downsample", int_t, 0, "Downsample ratio", 2, 0, 3,
         edit_method = downsample_enum)
 

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_bidirectional_stereo_matcher.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_bidirectional_stereo_matcher.h
@@ -31,8 +31,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#ifndef VX_STEREO_MATCHER_H
-#define VX_STEREO_MATCHER_H
+#pragma once
 
 #include <NVX/nvx.h>
 #include <VX/vx.h>
@@ -42,9 +41,10 @@
 
 #include "gpu_stereo_image_proc/visionworks/vx_stereo_matcher.h"
 
+namespace gpu_stereo_image_proc_visionworks {
+
 class VXBidirectionalStereoMatcher : public VXStereoMatcherBase {
  public:
-  VXBidirectionalStereoMatcher();
   VXBidirectionalStereoMatcher(const VXStereoMatcherParams &params);
 
   ~VXBidirectionalStereoMatcher();
@@ -73,10 +73,13 @@ class VXBidirectionalStereoMatcher : public VXStereoMatcherBase {
     int lrc_threshold;
   } _wls_params;
 
+ protected:
+  VXBidirectionalStereoMatcher() = delete;
+
   // This class is non-copyable
   VXBidirectionalStereoMatcher(const VXBidirectionalStereoMatcher &) = delete;
   VXBidirectionalStereoMatcher &operator=(
       const VXBidirectionalStereoMatcher &) = delete;
 };
 
-#endif
+}  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_bidirectional_stereo_matcher.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_bidirectional_stereo_matcher.h
@@ -56,9 +56,7 @@ class VXBidirectionalStereoMatcher : public VXStereoMatcherBase {
   cv::Mat confidenceMat() const { return confidence_; }
 
   cv::Mat RLDisparityMat() const {
-    nvx_cv::VXImageToCVMatMapper map(flipped_rl_disparity_, 0, NULL,
-                                     VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
-    return map.getMat();
+    return vxImageToMatWrapper(flipped_rl_disparity_);
   }
 
  private:
@@ -73,7 +71,7 @@ class VXBidirectionalStereoMatcher : public VXStereoMatcherBase {
     int lrc_threshold;
   } _wls_params;
 
- protected:
+  // No default constructor
   VXBidirectionalStereoMatcher() = delete;
 
   // This class is non-copyable

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_conversions.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_conversions.h
@@ -48,8 +48,6 @@
     ROS_ASSERT(status == VX_SUCCESS);                   \
   } while (false)
 
-// using std::cout;
-// using std::endl;
-
 void copy_to_vx_image(cv::InputArray src, vx_image dest);
-// void copy_from_vx_image(vx_image src, cv::OutputArray dest);
+
+cv::Mat vxImageToMatWrapper(vx_image image);

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_image_scaler.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_image_scaler.h
@@ -44,19 +44,23 @@ namespace gpu_stereo_image_proc_visionworks {
 
 class VxImageScaler {
  public:
-  VxImageScaler(unsigned int downsample_log2)
-      : downsample_log2_(downsample_log2) {}
+  VxImageScaler(unsigned int downsample_log2);
 
   virtual vx_image addToGraph(vx_context context, vx_graph graph,
                               vx_image input) = 0;
 
   int downsample() const { return 2 ^ downsample_log2_; }
 
+  // Note outputSize() is not set until addToGraph is called
   const cv::Size outputSize() const { return output_size_; }
 
   unsigned int downsample_log2_;
+
+ protected:
   cv::Size output_size_;
 
+  // No default constructor
+  VxImageScaler() = delete;
   // The class is non-copyable
   VxImageScaler(const VxImageScaler &) = delete;
   VxImageScaler &operator=(const VxImageScaler &) = delete;
@@ -64,17 +68,18 @@ class VxImageScaler {
 
 class VxGaussianImageScaler : public VxImageScaler {
  public:
-  VxGaussianImageScaler(unsigned int downsample_log2)
-      : VxImageScaler(downsample_log2), images_(downsample_log2) {
-    ;
-  }
+  VxGaussianImageScaler(unsigned int downsample_log2);
 
   vx_image addToGraph(vx_context context, vx_graph graph,
                       vx_image input) override;
 
-  // This class operates by factors of 2, so it needs the whole pyramid
+ protected:
+  // This class downsamples using a Visionworks call which halves image size,
+  // so we maintain a pyramid of intermediate images
   std::vector<vx_image> images_;
 
+  // No default constructor
+  VxGaussianImageScaler() = delete;
   // The class is non-copyable
   VxGaussianImageScaler(const VxGaussianImageScaler &) = delete;
   VxGaussianImageScaler &operator=(const VxGaussianImageScaler &) = delete;

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher.h
@@ -39,6 +39,7 @@
 #include <ros/ros.h>
 
 #include <opencv2/core.hpp>
+#include <opencv2/core/cuda.hpp>
 
 #include "gpu_stereo_image_proc/visionworks/vx_stereo_matcher_base.h"
 
@@ -65,14 +66,14 @@ class VXStereoMatcher : public VXStereoMatcherBase {
   }
 
  protected:
+  // GpuMat which stores the result **if** filtering is enabled
+  cv::cuda::GpuMat g_filtered_;
+
   VXStereoMatcher() = delete;
 
   // noncopyable
   VXStereoMatcher(const VXStereoMatcher &) = delete;
   VXStereoMatcher &operator=(const VXStereoMatcher &) = delete;
-
-  // GpuMat which stores the result **if** filtering is enabled
-  cv::cuda::GpuMat g_filtered_;
 };
 
 }  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_base.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_base.h
@@ -38,10 +38,10 @@
 #include <VX/vxu.h>
 #include <ros/ros.h>
 
-#include <NVX/nvx_opencv_interop.hpp>
 #include <memory>
 #include <opencv2/core.hpp>
 
+#include "gpu_stereo_image_proc/visionworks/vx_conversions.h"
 #include "gpu_stereo_image_proc/visionworks/vx_image_scaler.h"
 #include "gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h"
 
@@ -58,23 +58,12 @@ class VXStereoMatcherBase {
   const VXStereoMatcherParams &params() const { return params_; }
 
   cv::Mat unfilteredDisparityMat() const {
-    cv::Mat output;
-    nvx_cv::VXImageToCVMatMapper map(disparity_, 0, NULL, VX_READ_ONLY,
-                                     VX_MEMORY_TYPE_HOST);
-    return map.getMat();
+    return vxImageToMatWrapper(disparity_);
   }
 
-  cv::Mat scaledLeftRect() const {
-    nvx_cv::VXImageToCVMatMapper map(left_scaled_, 0, NULL, VX_READ_ONLY,
-                                     VX_MEMORY_TYPE_HOST);
-    return map.getMat();
-  }
+  cv::Mat scaledLeftRect() const { return vxImageToMatWrapper(left_scaled_); }
 
-  virtual cv::Mat disparity() const {
-    nvx_cv::VXImageToCVMatMapper map(disparity_, 0, NULL, VX_READ_ONLY,
-                                     VX_MEMORY_TYPE_HOST);
-    return map.getMat();
-  }
+  virtual cv::Mat disparity() const { return vxImageToMatWrapper(disparity_); }
 
  protected:
   vx_context context_;
@@ -84,7 +73,7 @@ class VXStereoMatcherBase {
   vx_image left_image_;
   vx_image right_image_;
 
-  // Scaled images (equal to {left|right}_imag_ if not scaling)
+  // Scaled images (equal to {left|right}_image_ if not scaling)
   vx_image left_scaled_;
   vx_image right_scaled_;
 

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_base.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_base.h
@@ -39,14 +39,16 @@
 #include <ros/ros.h>
 
 #include <NVX/nvx_opencv_interop.hpp>
+#include <memory>
 #include <opencv2/core.hpp>
 
+#include "gpu_stereo_image_proc/visionworks/vx_image_scaler.h"
 #include "gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h"
+
+namespace gpu_stereo_image_proc_visionworks {
 
 class VXStereoMatcherBase {
  public:
-  VXStereoMatcherBase();
-
   VXStereoMatcherBase(const VXStereoMatcherParams &params);
 
   virtual ~VXStereoMatcherBase();
@@ -63,15 +65,9 @@ class VXStereoMatcherBase {
   }
 
   cv::Mat scaledLeftRect() const {
-    if (params().downsample != 1) {
-      nvx_cv::VXImageToCVMatMapper map(left_scaled_, 0, NULL, VX_READ_ONLY,
-                                       VX_MEMORY_TYPE_HOST);
-      return map.getMat();
-    } else {
-      nvx_cv::VXImageToCVMatMapper map(left_image_, 0, NULL, VX_READ_ONLY,
-                                       VX_MEMORY_TYPE_HOST);
-      return map.getMat();
-    }
+    nvx_cv::VXImageToCVMatMapper map(left_scaled_, 0, NULL, VX_READ_ONLY,
+                                     VX_MEMORY_TYPE_HOST);
+    return map.getMat();
   }
 
   virtual cv::Mat disparity() const {
@@ -83,16 +79,28 @@ class VXStereoMatcherBase {
  protected:
   vx_context context_;
   vx_graph graph_;
+
+  // Input images
   vx_image left_image_;
   vx_image right_image_;
 
+  // Scaled images (equal to {left|right}_imag_ if not scaling)
   vx_image left_scaled_;
   vx_image right_scaled_;
+
+  // Output images
   vx_image disparity_;
 
   VXStereoMatcherParams params_;
+
+  std::unique_ptr<VxImageScaler> left_scaler_, right_scaler_;
+
+  // No default constructor
+  VXStereoMatcherBase() = delete;
 
   // noncopyable
   VXStereoMatcherBase(const VXStereoMatcherBase &) = delete;
   VXStereoMatcherBase &operator=(const VXStereoMatcherBase &) = delete;
 };
+
+}  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h
@@ -108,19 +108,20 @@ struct VXStereoMatcherParams {
 
   void dump() const {
     ROS_INFO("===================================");
-    ROS_INFO("image_size  : w %d, h %d", image_size().width,
+    ROS_INFO("original img size : w %d, h %d", image_size().width,
              image_size().height);
-    ROS_INFO("downsample  : %d", downsample());
-    ROS_INFO("Uniqueness  : %d", uniqueness_ratio);
-    ROS_INFO("Max Diff    : %d", max_diff);
-    ROS_INFO("P1/P2       : P1 %d, P2 %d", P1, P2);
-    ROS_INFO("Win Size    : SAD %d, CT %d, HC %d", sad_win_size, ct_win_size,
-             hc_win_size);
-    ROS_INFO("Clip        : %d", clip);
-    ROS_INFO("Min/Max Disp: min %d, max %d", min_disparity, max_disparity);
-    ROS_INFO("ScanType    : %02X", scanline_mask);
-    ROS_INFO("Flags       : %02X", flags);
-    ROS_INFO("Filtering   : %s", disparity_filter_as_string());
+    ROS_INFO("       Downsample : %d", downsample());
+    ROS_INFO("       Uniqueness : %d", uniqueness_ratio);
+    ROS_INFO("         Max Diff : %d", max_diff);
+    ROS_INFO("            P1/P2 : P1 %d, P2 %d", P1, P2);
+    ROS_INFO("         Win Size : SAD %d, CT %d, HC %d", sad_win_size,
+             ct_win_size, hc_win_size);
+    ROS_INFO("             Clip : %d", clip);
+    ROS_INFO("     Min/Max Disp : min %d, max %d", min_disparity,
+             max_disparity);
+    ROS_INFO("   Scan type mask : 0x%02X", scanline_mask);
+    ROS_INFO("            Flags : %02X", flags);
+    ROS_INFO("        Filtering : %s", disparity_filter_as_string());
     ROS_INFO("===================================");
   }
 

--- a/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h
+++ b/gpu_stereo_image_proc_visionworks/include/gpu_stereo_image_proc/visionworks/vx_stereo_matcher_params.h
@@ -33,6 +33,8 @@
  *********************************************************************/
 #pragma once
 
+namespace gpu_stereo_image_proc_visionworks {
+
 struct VXStereoMatcherParams {
  public:
   enum DisparityFiltering_t {
@@ -43,7 +45,7 @@ struct VXStereoMatcherParams {
   };
 
   VXStereoMatcherParams()
-      : downsample(2),
+      : downsample_log2(0),
         min_disparity(0),
         max_disparity(64),
         P1(8),
@@ -64,11 +66,13 @@ struct VXStereoMatcherParams {
 
   const cv::Size image_size() const { return _image_size; }
   const cv::Size scaled_image_size() const {
-    return cv::Size(_image_size.width / downsample,
-                    _image_size.height / downsample);
+    return cv::Size(_image_size.width >> downsample_log2,
+                    _image_size.height >> downsample_log2);
   }
 
-  int downsample;
+  int downsample() const { return (1 << downsample_log2); }
+
+  int downsample_log2;
   int min_disparity;
   int max_disparity;
 
@@ -106,7 +110,7 @@ struct VXStereoMatcherParams {
     ROS_INFO("===================================");
     ROS_INFO("image_size  : w %d, h %d", image_size().width,
              image_size().height);
-    ROS_INFO("downsample  : %d", downsample);
+    ROS_INFO("downsample  : %d", downsample());
     ROS_INFO("Uniqueness  : %d", uniqueness_ratio);
     ROS_INFO("Max Diff    : %d", max_diff);
     ROS_INFO("P1/P2       : P1 %d, P2 %d", P1, P2);
@@ -153,3 +157,5 @@ struct VXStereoMatcherParams {
   // if (ratio < 0.0 || ratio > 100.0)
   //   return false;
 };
+
+}  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/nodelet_plugins.xml
+++ b/gpu_stereo_image_proc_visionworks/nodelet_plugins.xml
@@ -1,6 +1,6 @@
 <library path="lib/libvx_stereo_image_proc">
 
-  <class name="gpu_stereo_image_proc_visionworks/vx_disparity" type="gpu_stereo_image_proc::VXDisparityNodelet" base_class_type="nodelet::Nodelet">
+  <class name="gpu_stereo_image_proc_visionworks/vx_disparity" type="gpu_stereo_image_proc_visionworks::VXDisparityNodelet" base_class_type="nodelet::Nodelet">
     <description>Nodelet to perform stereo processing on a pair of rectified image streams, producing disparity images</description>
   </class>
 

--- a/gpu_stereo_image_proc_visionworks/src/vx_conversions.cpp
+++ b/gpu_stereo_image_proc_visionworks/src/vx_conversions.cpp
@@ -34,8 +34,7 @@
 
 #include "gpu_stereo_image_proc/visionworks/vx_conversions.h"
 
-using std::cout;
-using std::endl;
+#include <NVX/nvx_opencv_interop.hpp>
 
 void copy_to_vx_image(cv::InputArray src, vx_image dest) {
   cv::Mat src_mat = src.getMat();
@@ -61,4 +60,10 @@ void copy_to_vx_image(cv::InputArray src, vx_image dest) {
   const auto status = vxCopyImagePatch(dest, &rect, 0, &addr, src_mat.data,
                                        VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
   // ROS_ASSERT(status == VX_SUCCESS);
+}
+
+cv::Mat vxImageToMatWrapper(vx_image image) {
+  nvx_cv::VXImageToCVMatMapper map(image, 0, NULL, VX_READ_ONLY,
+                                   VX_MEMORY_TYPE_HOST);
+  return map.getMat();
 }

--- a/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
+++ b/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
@@ -35,6 +35,14 @@
 
 namespace gpu_stereo_image_proc_visionworks {
 
+VxImageScaler::VxImageScaler(unsigned int downsample_log2)
+    : downsample_log2_(downsample_log2) {}
+
+VxGaussianImageScaler::VxGaussianImageScaler(unsigned int downsample_log2)
+    : VxImageScaler(downsample_log2), images_(downsample_log2) {
+  ;
+}
+
 vx_image VxGaussianImageScaler::addToGraph(vx_context context, vx_graph graph,
                                            vx_image input) {
   // Retrieve size of input image

--- a/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
+++ b/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
@@ -1,0 +1,90 @@
+/*********************************************************************
+ *  Copyright (c) 2023 University of Washington
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include "gpu_stereo_image_proc/visionworks/vx_image_scaler.h"
+
+#include "gpu_stereo_image_proc/visionworks/vx_conversions.h"
+
+namespace gpu_stereo_image_proc_visionworks {
+
+vx_image VxGaussianImageScaler::addToGraph(vx_context context, vx_graph graph,
+                                           vx_image input) {
+  // Retrieve size of input image
+  vx_uint32 input_width, input_height;
+  assert(VX_SUCCESS ==
+         vxQueryImage(input, VX_IMAGE_WIDTH, &input_width, sizeof(vx_uint32)));
+  assert(VX_SUCCESS == vxQueryImage(input, VX_IMAGE_HEIGHT, &input_height,
+                                    sizeof(vx_uint32)));
+
+  if (downsample_log2_ == 0) {
+    output_size_.width = input_width;
+    output_size_.height = input_height;
+    return input;
+  }
+
+  vx_df_image input_format;
+  assert(VX_SUCCESS == vxQueryImage(input, VX_IMAGE_FORMAT, &input_format,
+                                    sizeof(vx_df_image)));
+
+  uint32_t layer_width = input_width;
+  uint32_t layer_height = input_height;
+
+  const vx_int32 gaussian_kernel_size = 3;
+
+  for (int i = 0; i < downsample_log2_; i++) {
+    layer_width = (layer_width + 1) / 2;
+    layer_height = (layer_height + 1) / 2;
+
+    images_[i] =
+        vxCreateImage(context, layer_width, layer_height, input_format);
+
+    VX_CHECK_STATUS(vxGetStatus((vx_reference)images_[i]));
+
+    if (i == 0) {
+      vx_node scale_node = vxHalfScaleGaussianNode(graph, input, images_[0],
+                                                   gaussian_kernel_size);
+      vxReleaseNode(&scale_node);
+    } else {
+      vx_node scale_node = vxHalfScaleGaussianNode(
+          graph, images_[i - 1], images_[i], gaussian_kernel_size);
+
+      VX_CHECK_STATUS(vxVerifyGraph(graph));
+      vxReleaseNode(&scale_node);
+    }
+  }
+
+  output_size_.width = layer_width;
+  output_size_.height = layer_height;
+
+  return input;
+}
+
+}  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
+++ b/gpu_stereo_image_proc_visionworks/src/vx_image_scaler.cpp
@@ -84,7 +84,7 @@ vx_image VxGaussianImageScaler::addToGraph(vx_context context, vx_graph graph,
   output_size_.width = layer_width;
   output_size_.height = layer_height;
 
-  return input;
+  return images_.back();
 }
 
 }  // namespace gpu_stereo_image_proc_visionworks

--- a/gpu_stereo_image_proc_visionworks/src/vx_stereo_matcher.cpp
+++ b/gpu_stereo_image_proc_visionworks/src/vx_stereo_matcher.cpp
@@ -44,13 +44,13 @@
 
 #include "gpu_stereo_image_proc/visionworks/vx_conversions.h"
 
-VXStereoMatcher::VXStereoMatcher() : VXStereoMatcherBase() {}
+namespace gpu_stereo_image_proc_visionworks {
 
 VXStereoMatcher::VXStereoMatcher(const VXStereoMatcherParams &params)
     : VXStereoMatcherBase(params) {
   vx_status status;
 
-  if (params.downsample > 1) {
+  if (params.downsample_log2 > 0) {
     // left_scaled_ = vxCreateImage( context_,
     //     params.scaled_image_size().width, params.scaled_image_size().height,
     //     VX_DF_IMAGE_U8);
@@ -116,3 +116,5 @@ void VXStereoMatcher::compute(cv::InputArray left, cv::InputArray right) {
                           g_filtered_);
   }
 }
+
+}  // namespace gpu_stereo_image_proc_visionworks


### PR DESCRIPTION
Implements the enhancement described in issue #10.   Uses a different Visionworks call to resize images which can only halve image dimensions, so we restrict image downsampling to powers of 2.