### PR TITLE
Fix VPI median filter

### DIFF
--- a/gpu_stereo_image_proc_vpi/CMakeLists.txt
+++ b/gpu_stereo_image_proc_vpi/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 # See note in image_proc/CMakeLists.txt
 add_definitions(-DOPENCV_TRAITS_ENABLE_DEPRECATED)
 
-include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${vpi_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${vpi_INCLUDE_DIRS} ${CUDA_INCLUDE_DIRS})
 
 #  Library (and nodelet)
 set(VPI_NODELET_NAME vpi_stereo_image_proc)

--- a/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher.h
+++ b/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher.h
@@ -32,13 +32,12 @@
 #pragma once
 
 #include <ros/ros.h>
-
-#include <opencv2/core.hpp>
-// #include <opencv2/core/cuda.hpp>
-
 #include <vpi/Image.h>
 #include <vpi/Stream.h>
 #include <vpi/algo/StereoDisparity.h>
+
+#include <opencv2/core.hpp>
+#include <opencv2/core/cuda.hpp>
 
 #include "gpu_stereo_image_proc/vpi/vpi_stereo_matcher_params.h"
 
@@ -71,11 +70,11 @@ class VPIStereoMatcher {
   VPIImage left_scaled_, right_scaled_;
 
   // These are VPI wrappers around gpuMats
-  cv::GpuMat disparity_gpu_mat_, disparity_filtered_gpu_mat_,
+  cv::cuda::GpuMat disparity_gpu_mat_, disparity_filtered_gpu_mat_,
       disparity_output_gpu_mat_, confidence_gpu_mat_, left_scaled_gpu_mat_,
       right_scaled_gpu_mat_;
 
-  VPIImage disparity_, disparity_filtered_, disparity_output_, confidence_;
+  VPIImage disparity_, disparity_filtered_, confidence_;
 
   VPIStereoMatcherParams params_;
 

--- a/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher.h
+++ b/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher.h
@@ -65,8 +65,15 @@ class VPIStereoMatcher {
   VPIPayload stereo_payload_;
   VPIStream stream_;
 
+  // These are "real" VPIImages (allocated by VPI)
   VPIImage left_blurred_, right_blurred_;
+
   VPIImage left_scaled_, right_scaled_;
+
+  // These are VPI wrappers around gpuMats
+  cv::GpuMat disparity_gpu_mat_, disparity_filtered_gpu_mat_,
+      disparity_output_gpu_mat_, confidence_gpu_mat_, left_scaled_gpu_mat_,
+      right_scaled_gpu_mat_;
 
   VPIImage disparity_, disparity_filtered_, disparity_output_, confidence_;
 

--- a/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher_params.h
+++ b/gpu_stereo_image_proc_vpi/include/gpu_stereo_image_proc/vpi/vpi_stereo_matcher_params.h
@@ -80,7 +80,7 @@ struct VPIStereoMatcherParams {
     ROS_INFO("~~ VPI Matcher ~~");
     ROS_INFO("original img size : w %d, h %d", image_size().width,
              image_size().height);
-    ROS_INFO("       Downsample : %d", downsample());
+    ROS_INFO("       Downsample : x%d", downsample());
     ROS_INFO(" Confidence threshold : %d", confidence_threshold);
     ROS_INFO("               P1 : %f", p1);
     ROS_INFO("               P2 : %f", p2);


### PR DESCRIPTION
This PR fixes an issue with using the median filter in `gpu_stereo_image_proc_vpi` on `jetpack-5..1.2`

To fix, switched from using VPIImages created using createVPIImage to creating cv::cuda::GpuMats, then wrapping them in VPIImages, allowing use of the buffers in either VPI or cv::Cuda.